### PR TITLE
Use 'oneof' instead of 'elements' to select symbol

### DIFF
--- a/src/Test/QuickCheck/Utf8.hs
+++ b/src/Test/QuickCheck/Utf8.hs
@@ -32,7 +32,7 @@ genValidUtf8 = fmap decodeUtf8 utf8BS
 -- Generate a possibly-empty sequence of bytes which represent a valid
 -- UTF-8 code point.
 utf8BS :: Gen ByteString
-utf8BS = fmap BS.concat $ elements symbolTypes  >>= listOf
+utf8BS = fmap BS.concat . listOf $ oneof symbolTypes
 
 -- |
 -- Like 'genValidUtf8', but does not allow empty 'Text' values.
@@ -42,7 +42,7 @@ genValidUtf81 = fmap decodeUtf8 utf8BS1
 -- |
 -- Like 'utf8BS', but does not allow empty 'ByteString's.
 utf8BS1 :: Gen ByteString
-utf8BS1 = fmap BS.concat $ elements symbolTypes  >>= listOf1
+utf8BS1 = fmap BS.concat . listOf1 $ oneof symbolTypes
 
 symbolTypes :: [Gen ByteString]
 symbolTypes = [ oneByte


### PR DESCRIPTION
This means every character can choose a different symbol type.

Previously the generated string would always have included exclusively one byte, two byte or three byte characters.
